### PR TITLE
Bug 1395766: Very small font size for <rt> inside <rtc> when lang="zh…

### DIFF
--- a/layout/style/res/html.css
+++ b/layout/style/res/html.css
@@ -873,14 +873,14 @@ rp {
 }
 rt {
   display: ruby-text;
+  font-size: 50%;
+  -moz-min-font-size-ratio: 50%;
 }
 rtc {
   display: ruby-text-container;
 }
 rtc, rt {
   white-space: nowrap;
-  font-size: 50%;
-  -moz-min-font-size-ratio: 50%;
   line-height: 1;
 %ifndef XP_WIN
   /* The widely-used Windows font Meiryo doesn't work fine with this
@@ -894,10 +894,6 @@ rtc, rt {
 }
 rtc:lang(zh), rt:lang(zh) {
   ruby-align: center;
-}
-rtc:lang(zh-TW), rt:lang(zh-TW) {
-  font-size: 30%; /* bopomofo */
-  -moz-min-font-size-ratio: 30%;
 }
 rtc > rt {
   font-size: inherit;


### PR DESCRIPTION
…-TW"

See https://bugzilla.mozilla.org/show_bug.cgi?id=1395766.

1. Move `font-size: 50%` and ` -moz-min-font-size-ratio: 50%` to `rt` elements only (to the exclusion of `rtc` elements).
2. Remove Taiwanese Chinese font size rule (with `30%` values on the same properties) targeted at bopomofo.

(Regarding item 2, the correct selector for bopomofo targeting is `:lang("*-Bopo")` (not `:lang(zh-TW)`) and can't be done properly without CSS4 Selectors "wildcard matching"; see https://drafts.csswg.org/selectors-4/#the-lang-pseudo. This also leads to weirdness where `zh`, `zh-Bopo`, `zh-Bopo-TW`, and `zh-TW` don't produce the same font size.)